### PR TITLE
Fix typos and elisions in README

### DIFF
--- a/README
+++ b/README
@@ -139,11 +139,12 @@ runs out, we generate a new batch of ChaCha20 output using the Key and IV we
 had set aside, and start the process over.
 
 Note that since we destroy each key as soon as we use it, and overwrite each
-part of the stream as soon as we yield it, we shouldn't.
+part of the stream as soon as we yield it, we shouldn't have any issues with
+information leaks.
 
 === API
 
-Libttery-lite can main API modes: built-in, stateful, and arc4
+Libottery-lite has 3 main API modes: built-in, stateful, and arc4
 emulation.  By default, we build in built-in mode, and the available
 APIs are as follow:
 


### PR DESCRIPTION
Finish the sentence at the end of Cryptography, probably incorrectly.
Name the library correctly.
Count the API modes and complete the sentence, possibly incorrectly.
