### PR TITLE
MSVC 2013 build fix

### DIFF
--- a/src/otterylite_locking.h
+++ b/src/otterylite_locking.h
@@ -14,8 +14,9 @@
   static void name(void) __attribute__((constructor));  \
   static void name(void)
 #elif defined(_MSC_VER)
-#define INITIALIZER_FUNC(name)                                          \
-  static void __cdecl name(void);                                       \
+#pragma section(".CRT$XCU",read)
+#define INITIALIZER_FUNC(name)                                              \
+  static void __cdecl name(void);                                           \
   __declspec(allocate(".CRT$XCU")) void(__cdecl * name ## _) (void) = name; \
   static void name(void)
 #endif

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -9,10 +9,6 @@
 
 #include "otterylite.c"
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #include "tinytest.h"
 #include "tinytest_macros.h"
 

--- a/test/tinytest/tinytest.h
+++ b/test/tinytest/tinytest.h
@@ -26,6 +26,10 @@
 #ifndef TINYTEST_H_INCLUDED_
 #define TINYTEST_H_INCLUDED_
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 /** Flag for a test that needs to run in a subprocess. */
 #define TT_FORK  (1<<0)
 /** Runtime flag for a test we've decided to skip. */


### PR DESCRIPTION
`__declspec(allocate("section name"))` [requires the section to already exist](https://msdn.microsoft.com/en-us/library/5bkb2w6t.aspx). In the case where there are no nontrivial initializers in an application that implicitly create this section, compilation will fail on MSVC.

Additionally, moved the `_snprintf` alias to `tinytest.h` to be able to compile tests.
